### PR TITLE
Use previously build container as cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - name: Get latest code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Get previous commit SHA
+        id: prev_sha
+        run: |
+          echo "::set-output name=sha::$(git rev-parse HEAD^)"
       - name: Login to registry
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin ${{ secrets.DOCKER_REGISTRY }}
       - name: "Setup Docker Buildx"
@@ -22,6 +28,7 @@ jobs:
           context: .
           push: true
           tags: ${{ secrets.DOCKER_REGISTRY }}/personal-blog:${{ github.sha }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_REGISTRY }}/personal-blog:${{ steps.prev_sha.outputs.sha }}
           # Diabled due to cloudflares upload limit.
           # Seems like the buildcache is generating at least one large layer.
           # cache-from: type=registry,ref=${{ secrets.DOCKER_REGISTRY }}/personal-blog:buildcache
@@ -29,7 +36,7 @@ jobs:
 
   release-on-kubernetes:
     runs-on: ubuntu-latest
-    # needs: build-and-push-container
+    needs: build-and-push-container
     steps:
       - name: Get latest code
         uses: actions/checkout@v4


### PR DESCRIPTION
Will merge as is, seems as if downloading the cache image takes more time than building it from ground up.